### PR TITLE
fixed calls to print for py3

### DIFF
--- a/flask_common.py
+++ b/flask_common.py
@@ -133,11 +133,11 @@ class Common(object):
     def serve(self, workers=None, **kwargs):
         """Serves the Flask application."""
         if self.app.debug:
-            print crayons.yellow('Booting Flask development server...')
+            print(crayons.yellow('Booting Flask development server...'))
             self.app.run()
 
         else:
-            print crayons.yellow('Booting Gunicorn...')
+            print(crayons.yellow('Booting Gunicorn...'))
 
             # Start the web server.
             server = GunicornServer(self.app, workers=workers or number_of_gunicorn_workers(), **kwargs)


### PR DESCRIPTION
I ran into two small issues with `print()` while running this under Python 3.6.