### PR TITLE
don't hard fail on warning suppression

### DIFF
--- a/flask_common.py
+++ b/flask_common.py
@@ -9,10 +9,12 @@ from gunicorn.app.base import Application
 from whitenoise import WhiteNoise
 from flask_cache import Cache
 
-import warnings
-from flask.exthook import ExtDeprecationWarning
-
-warnings.simplefilter('ignore', ExtDeprecationWarning)
+try:
+    from flask.exthook import ExtDeprecationWarning
+    import warnings
+    warnings.simplefilter('ignore', ExtDeprecationWarning)
+except ImportError:
+    pass # DeprecationWarning only relevant to Flask<1.0
 
 
 # Find the stack on which we want to store the database connection.


### PR DESCRIPTION
The only use we have of the `exthook` module is to suppress a warning about the removal of the `exthook` module. I'm assuming this was added to prevent console/log spam due to an external dependency. We should try to determine if there is still a problem, and remove this entirely if it's not.

This will get httpbin moving again though for the time being.